### PR TITLE
Fixes ring disappearing when putting gloves in pocket

### DIFF
--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -460,10 +460,10 @@ BLIND     // can't see anything
 		species_restricted -= SPECIES_UNATHI
 	return
 
-/obj/item/clothing/gloves/mob_can_equip(mob/user)
+/obj/item/clothing/gloves/mob_can_equip(mob/user, slot)
 	var/mob/living/carbon/human/H = user
 
-	if(istype(H.gloves, /obj/item/clothing/ring))
+	if(istype(H.gloves, /obj/item/clothing/ring) && slot == slot_gloves)
 		ring = H.gloves
 		if(!ring.undergloves)
 			to_chat(user, "You are unable to wear \the [src] as \the [H.gloves] are in the way.")


### PR DESCRIPTION
:cl: Fre3bie, Runebyt3, Ryan180602
bugfix: Rings no longer vanish from hands when putting gloves in pockets
/:cl:

A quick check if the slot being equipped to is the glove as opposed to the pocket or anything else, to ensure the ring is only "hidden" when a glove is put on top of it.

Love when a solution is super simple after trying much more complicated fixes.